### PR TITLE
fix a bug in `_convert_output_type_range`

### DIFF
--- a/mmcv/image/colorspace.py
+++ b/mmcv/image/colorspace.py
@@ -97,14 +97,14 @@ def _convert_input_type_range(img: np.ndarray) -> np.ndarray:
 
     Returns:
         (ndarray): The converted image with type of np.float32 and range of
-            [0, 1].
+            [0, 255].
     """
     img_type = img.dtype
     img = img.astype(np.float32)
     if img_type == np.float32:
-        pass
+        img *= 255.
     elif img_type == np.uint8:
-        img /= 255.
+        pass
     else:
         raise TypeError('The img type should be np.float32 or np.uint8, '
                         f'but got {img_type}')


### PR DESCRIPTION
## Motivation

The calculation in `rgb2ycbcr` and `bgr2ycbcr` is based on data with range [0, 255].

## Modification

Keep the data with range [0, 255] when dtype=np.uint8.
Enlarge the data with range [0, 1] when dtype=np.float32.

## BC-breaking (Optional)

No

## Use cases (Optional)

Two function calls : `rgb2ycbcr` , `bgr2ycbcr`.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
